### PR TITLE
set `ssaflags`

### DIFF
--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -577,7 +577,7 @@ function overdub_pass!(reflection::Reflection,
     code_info.code = overdubbed_code
     code_info.codelocs = overdubbed_codelocs
     code_info.ssavaluetypes = length(overdubbed_code)
-    code_info.ssaflags = [0x00 for _ in 1:length(overdubbed_code)] # XXX we need to flags that are set for the original code
+    code_info.ssaflags = [0x00 for _ in 1:length(overdubbed_code)] # XXX we need to copy flags that are set for the original code
     reflection.code_info = code_info
 
     return reflection

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -577,6 +577,7 @@ function overdub_pass!(reflection::Reflection,
     code_info.code = overdubbed_code
     code_info.codelocs = overdubbed_codelocs
     code_info.ssavaluetypes = length(overdubbed_code)
+    code_info.ssaflags = [0x00 for _ in 1:length(overdubbed_code)] # XXX we need to flags that are set for the original code
     reflection.code_info = code_info
 
     return reflection


### PR DESCRIPTION
On recent master, `(code_info::CodeInfo).ssaflags` might be set before
inference and observed during inference, and the overdubbing mechanism
should modify it so that its length matches the length of statements
(otherwise inference code throws).

Ideally we should respect flags that are originally set though.