### PR TITLE
update for 1.10

### DIFF
--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -642,6 +642,18 @@ if VERSION >= v"1.4.0-DEV.304"
 end
 
 let line = @__LINE__, file = @__FILE__
+    @static if VERSION >= v"1.10.0-DEV.873"
+    @eval (@__MODULE__) begin
+        function $Cassette.overdub($OVERDUB_CONTEXT_NAME::$Cassette.Context, $OVERDUB_ARGUMENTS_NAME...)
+            $(Expr(:meta, :generated_only))
+            $(Expr(:meta, :generated, __overdub_generator__))
+        end
+        function $Cassette.recurse($OVERDUB_CONTEXT_NAME::$Cassette.Context, $OVERDUB_ARGUMENTS_NAME...)
+            $(Expr(:meta, :generated_only))
+            $(Expr(:meta, :generated, __overdub_generator__))
+        end
+    end
+    else
     @eval (@__MODULE__) begin
         function $Cassette.overdub($OVERDUB_CONTEXT_NAME::$Cassette.Context, $OVERDUB_ARGUMENTS_NAME...)
             $(Expr(:meta, :generated_only))
@@ -669,6 +681,7 @@ let line = @__LINE__, file = @__FILE__
                         QuoteNode(Symbol(file)),
                         true)))
         end
+    end
     end
 end
 

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -602,7 +602,10 @@ const OVERDUB_FALLBACK = begin
 end
 
 # `args` is `(typeof(original_function), map(typeof, original_args_tuple)...)`
-function __overdub_generator__(self, context_type, args::Tuple)
+function __overdub_generator__(world, source, self, context_type, args)
+    __overdub_generator__(self, context_type, args)
+end
+function __overdub_generator__(self, context_type, args)
     if nfields(args) > 0
         is_builtin = args[1] <: Core.Builtin
         is_invoke = args[1] === typeof(Core.invoke)

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -118,7 +118,11 @@ function reflect(@nospecialize(sigtypes::Tuple), world::UInt = get_world_counter
     method_instance === nothing && return nothing
     method_signature = method.sig
     static_params = Any[raw_static_params...]
-    code_info = Core.Compiler.retrieve_code_info(method_instance)
+    @static if VERSION >= v"1.10.0-DEV.873"
+        code_info = Core.Compiler.retrieve_code_info(method_instance, world)
+    else
+        code_info = Core.Compiler.retrieve_code_info(method_instance)
+    end
     isa(code_info, CodeInfo) || return nothing
     code_info = copy_code_info(code_info)
     verbose_lineinfo!(code_info, S)

--- a/test/misctests.jl
+++ b/test/misctests.jl
@@ -434,9 +434,11 @@ ctx = InvokeCtx(metadata=Any[])
 @test overdub(ctx, invoker, 3) === 9
 # This is kind of fragile and may break for unrelated reasons - the main thing
 # we're testing here is that we properly trace through the `invoke` call.
-@test ctx.metadata == Any[Core.apply_type, Core.invoke, Core.apply_type,
-                          Val{2}, Core.apply_type, Base.literal_pow, *,
-                          Base.mul_int] broken = VERSION >= v"1.9"
+if VERSION < v"1.9"
+    @test ctx.metadata == Any[Core.apply_type, Core.invoke, Core.apply_type,
+                              Val{2}, Core.apply_type, Base.literal_pow, *,
+                              Base.mul_int]
+end
 
 println("done (took ", time() - before_time, " seconds)")
 

--- a/test/misctests.jl
+++ b/test/misctests.jl
@@ -81,7 +81,7 @@ empty!(pres)
 empty!(posts)
 
 @overdub(ctx, Core._apply(+, (x1, x2), (x2 * x3, x3)))
-if v"1.9" <= VERSION < v"1.10"
+if !(v"1.9" <= VERSION < v"1.10")
     @test pres == [(tuple, (x1, x2)),
                    (*, (x2, x3)),
                    (Base.mul_int, (x2, x3)),
@@ -92,6 +92,17 @@ if v"1.9" <= VERSION < v"1.10"
                     (*(x2, x3), *, (x2, x3)),
                     ((x2*x3, x3), tuple, (x2*x3, x3)),
                     (+(x1, x2, x2*x3, x3), +, (x1, x2, x2*x3, x3))]
+else
+    @test pres == [(tuple, (x1, x2)),
+                   (*, (x2, x3)),
+                   (Base.mul_int, (x2, x3)),
+                   (tuple, (x2*x3, x3)),
+                   (Core._apply, (+, (x1, x2), (x2*x3, x3)))]
+    @test posts == [((x1, x2), tuple, (x1, x2)),
+                    (Base.mul_int(x2, x3), Base.mul_int, (x2, x3)),
+                    (*(x2, x3), *, (x2, x3)),
+                    ((x2*x3, x3), tuple, (x2*x3, x3)),
+                    (+(x1, x2, x2*x3, x3), Core._apply, (+, (x1, x2), (x2*x3, x3)))]
 end
 
 println("done (took ", time() - before_time, " seconds)")


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/48766 makes it so `retrieve_code_info` takes in a worldage, and dramatically simplifies construction of .